### PR TITLE
Moved find_package(OpenGL) to only be executed while building on apple

### DIFF
--- a/isis/cmake/FindAllDependencies.cmake
+++ b/isis/cmake/FindAllDependencies.cmake
@@ -76,6 +76,7 @@ find_package(Geos 3.5.0 REQUIRED)
 
 
 if(APPLE)
+  find_package(OpenGL            REQUIRED)
   find_package(Qt5 COMPONENTS
                   Core
                   Concurrent
@@ -182,8 +183,8 @@ find_package(TIFF      4.0.5   REQUIRED) # "tiff/tiff-${TIFF_FIND_VERSION}"
 find_package(TNT       126     REQUIRED) # TNT version is 1.2.6, but v007 directory is "tnt/tnt126/"
 find_package(XercesC   3.1.2   REQUIRED) # "xercesc/xercesc-${XercesC_FIND_VERSION}/"
 find_package(X11       6       REQUIRED)
-find_package(OpenGL            REQUIRED)
 find_package(Kakadu)
+
 
 # v007 might have different versions installed for our mac and linux systems.
 # Im this case, we specify the version numbers being searched for in the non-traditional installs.


### PR DESCRIPTION
Kelvin should review this and determine if it is okay because the line maybe necessary for the conda builds. I don't know if it is.

The line find_package(OpenGL)  breaks the Linux builds and works fine without this call. It seems more appropriate to move this to only be executed by the mac builds.

I am not sure if this line is necessary for linux builds for conda. If so then it needs to be implemented differently because it currently breaks on linux dev machines. 